### PR TITLE
Align scores to right

### DIFF
--- a/ui/src/main/webapp/assets/css/global-custom.css
+++ b/ui/src/main/webapp/assets/css/global-custom.css
@@ -158,3 +158,12 @@
 .font-source-code{
     font-family: 'Source Code Pro', monospace;
 }
+
+#tbl-leaderboard th {
+    text-align: right;
+}
+
+/* LeaderBoard table data*/
+#tbl-leaderboard td {
+    text-align: right;
+}


### PR DESCRIPTION
Fix for #10 
Align the scores column and the rank column of the leaderboard table. Also Fixed EOF issue in the global-custom.css file